### PR TITLE
Strip is param from YouTube URLs

### DIFF
--- a/core/links/youtube.go
+++ b/core/links/youtube.go
@@ -11,6 +11,7 @@ import (
 // YouTubeParamsToRemove are YouTube parameters that should be removed
 var YouTubeParamsToRemove = []string{
 	"si",
+	"is",
 	"app",
 	"feature",
 	"sqp",

--- a/core/links/youtube_test.go
+++ b/core/links/youtube_test.go
@@ -138,6 +138,16 @@ Another YouTube URL: https://youtu.be/test123`,
 			input:    "https://www.youtube.com/live/Q05BvncrHSc?si=abc123&other=keep",
 			expected: "https://youtu.be/Q05BvncrHSc?other=keep",
 		},
+		{
+			name:     "YouTube short URL with is tracking parameter",
+			input:    "https://youtu.be/BjSZlSAXwDc?is=8OI6ghw9aa62DDuA",
+			expected: "https://youtu.be/BjSZlSAXwDc",
+		},
+		{
+			name:     "YouTube short URL with is and other parameters",
+			input:    "https://youtu.be/BjSZlSAXwDc?is=8OI6ghw9aa62DDuA&other=keep",
+			expected: "https://youtu.be/BjSZlSAXwDc?other=keep",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

- Adds `is` to `YouTubeParamsToRemove` in `core/links/youtube.go`
- The `is` parameter is a YouTube tracking token appended during certain sharing flows (analogous to `si`)
- Example: `https://youtu.be/BjSZlSAXwDc?is=8OI6ghw9aa62DDuA` → `https://youtu.be/BjSZlSAXwDc`

## Test plan

- [ ] `go test ./core/links/... -run TestRemoveParamsFromYouTubeURLs` passes (2 new cases added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)