### PR TITLE
Strip adt_ei param from URLs

### DIFF
--- a/core/links/tracking.go
+++ b/core/links/tracking.go
@@ -17,6 +17,7 @@ var CommonTrackingParams = []string{
 	"_gl",
 	"_hsenc",
 	"_hsmi",
+	"adt_ei", // ActiveCampaign email tracking: encodes the recipient's email address to identify who clicked
 	"adgroupid",
 	"adheadline",
 	"campaign",

--- a/core/links/tracking_test.go
+++ b/core/links/tracking_test.go
@@ -60,6 +60,11 @@ func TestRemoveGenericTrackingParams(t *testing.T) {
 			expected: "https://towardsdatascience.com/stop-treating-ai-memory-like-a-search-problem/",
 		},
 		{
+			name:     "URL with ActiveCampaign email tracking parameter",
+			input:    "https://thatsourdoughgal.com/is-the-zacme-stand-mixer-worth-it-a-sourdough-bakers-honest-review/?adt_ei=user%40example.com",
+			expected: "https://thatsourdoughgal.com/is-the-zacme-stand-mixer-worth-it-a-sourdough-bakers-honest-review/",
+		},
+		{
 			name:     "URL with fragment tracking parameters",
 			input:    "https://musclemommasourdough.com/roasted-garlic-and-parmesan-sourdough-loaf/#growUnverifiedReaderId=4e75e57c-2848-4936-aa15-0e45cc7a0652&growAuthSource=espLink&growSource=espLink",
 			expected: "https://musclemommasourdough.com/roasted-garlic-and-parmesan-sourdough-loaf/",
@@ -182,6 +187,8 @@ func TestIsTrackingParam(t *testing.T) {
 		// HubSpot tracking parameters
 		{"_hsenc", true},
 		{"_hsmi", true},
+		// ActiveCampaign email tracking
+		{"adt_ei", true},
 		// Fragment tracking parameters
 		{"growUnverifiedReaderId", true},
 		{"growAuthSource", true},


### PR DESCRIPTION
## Summary

- Adds `adt_ei` to the list of common tracking parameters to strip
- `adt_ei` is an ActiveCampaign email tracking parameter that encodes the recipient's email address in the URL to identify who clicked a link in a campaign email
- Adds test case for a real `thatsourdoughgal.com` URL with this parameter

## Test plan

- [ ] `go test ./core/links/... -run TestRemoveGenericTrackingParams` passes (all 17 cases including the new ActiveCampaign one)
- [ ] `go test ./core/links/... -run TestIsTrackingParam` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)